### PR TITLE
Removed Console Reference Errors

### DIFF
--- a/spark_polymer.html
+++ b/spark_polymer.html
@@ -359,12 +359,12 @@ html /deep/ [segment], html /deep/ segment {
 </style>
 
 <script src="packages/polymer/src/js/polymer/polymer.min.js"></script>
-
+<!--
 <script>
 // TODO(sigmund): remove this script tag (dartbug.com/19650). This empty
 // script tag is necessary to work around a bug in Chrome 36.
 </script>
-
+-->
 <!-- unminified for debugging:
 <link rel="import" href="src/js/polymer/layout.html">
 <script src="src/js/polymer/polymer.js"></script>
@@ -4763,7 +4763,7 @@ button.ace_searchbtn[action="findAll"] {
 
   
 </polymer-element>
-<script src="third_party/analytics/google-analytics-bundle.js"></script><script src="packages/ace/src/js/ace.js"></script><script src="packages/ace/src/js/ext-language_tools.js"></script><script src="packages/ace/src/js/ext-linking.js"></script><script src="third_party/cssbeautify/cssbeautify.js"></script><script src="third_party/jshint/jshint.js"></script></div>
+<script src="third_party/analytics/google-analytics-bundle.js"></script><script src="packages/ace/src/js/ace.js"></script><script src="packages/ace/src/js/ext-language_tools.js"></script><script src="packages/ace/src/js/ext-linking.js"></script><script src="third_party/cssbeautify/cssbeautify.js"></script><!--<script src="third_party/jshint/jshint.js"></script>--></div>
   <!-- Template for FileItemCell -->
   <template id="fileview-filename-template">
     <div class="fileview-filename-container">


### PR DESCRIPTION
I've noticed the console had a number of errors while loading which made it difficult to troubleshoot when setting up on other computers. Commenting this code out removed those errors and still seems to run fine. I'm guessing the bug in Chrome 36 was fixed?